### PR TITLE
Fix double tracking fetch

### DIFF
--- a/src/views/ParcelTracker.vue
+++ b/src/views/ParcelTracker.vue
@@ -64,6 +64,11 @@ export default {
   },
   methods: {
     handleTrackParcel(trackingNumber) {
+      // update the input value immediately so the route watcher
+      // doesn't trigger another fetch when the URL changes
+      this.initialTrackingNumber = trackingNumber
+
+      // fetch mock tracking data for the provided number
       this.trackingData = this.getMockTrackingData(trackingNumber)
 
       if (this.$route.params.id !== trackingNumber) {


### PR DESCRIPTION
## Summary
- avoid duplicate fetches on tracking by updating initial tracking number before pushing new route

## Testing
- `npm run lint`
- `npm test -- --run` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_686665424cdc832aa0c6b211786e8497